### PR TITLE
Feat/pp solution export flags

### DIFF
--- a/azure-pipeline-templates/pac-solution/clone.yml
+++ b/azure-pipeline-templates/pac-solution/clone.yml
@@ -34,16 +34,29 @@ steps:
         $Debug = $env:Debug
         $SolutionUniqueName = $env:SolutionUniqueName
         $WorkingDirectory = $env:WorkingDirectory
+        $ProcessCanvasApps = $env:ProcessCanvasApps
 
         if ($Debug -eq $True) {
           Write-Host "##[debug]SolutionUniqueName=$SolutionUniqueName"
           Write-Host "##[debug]WorkingDirectory=$WorkingDirectory"
+          Write-Host "##[debug]ProcessCanvasApps=$ProcessCanvasApps"
+        }
+
+        $parameter = @(
+          "--name", "$SolutionUniqueName",
+          "--async",
+          "--packagetype", "Both"
+        )
+
+        if ($ProcessCanvasApps -eq $True) {
+          $parameter += "--processCanvasApps"
         }
 
         Write-Host "##[group]Cloning solution $SolutionUniqueName"
-        pac solution clone --name $SolutionUniqueName --async --processCanvasApps
+        & pac solution clone @parameter
         Write-Host "##[endgroup]"
     env:
       Debug: $(System.Debug)
       SolutionUniqueName: ${{ parameters.solutionUniqueName }}
       WorkingDirectory: ${{ parameters.outputDirectory }}
+      ProcessCanvasApps: $[ coalesce(variables.SolutionConfigProcessCanvasApps_Export, 'true') ]

--- a/azure-pipeline-templates/pac-solution/clone.yml
+++ b/azure-pipeline-templates/pac-solution/clone.yml
@@ -59,4 +59,4 @@ steps:
       Debug: $(System.Debug)
       SolutionUniqueName: ${{ parameters.solutionUniqueName }}
       WorkingDirectory: ${{ parameters.outputDirectory }}
-      ProcessCanvasApps: $[ coalesce(variables.SolutionConfigProcessCanvasApps_Export, 'true') ]
+      ProcessCanvasApps: $(SolutionConfigProcessCanvasApps_Export)

--- a/azure-pipeline-templates/pac-solution/sync.yml
+++ b/azure-pipeline-templates/pac-solution/sync.yml
@@ -34,16 +34,28 @@ steps:
         $Debug = $env:Debug
         $SolutionUniqueName = $env:SolutionUniqueName
         $WorkingDirectory = $env:WorkingDirectory
+        $ProcessCanvasApps = $env:ProcessCanvasApps
 
         if ($Debug -eq $True) {
           Write-Host "##[debug]SolutionUniqueName=$SolutionUniqueName"
           Write-Host "##[debug]WorkingDirectory=$WorkingDirectory"
+          Write-Host "##[debug]ProcessCanvasApps=$ProcessCanvasApps"
+        }
+
+        $parameter = @(
+          "--async",
+          "--packagetype", "Both"
+        )
+
+        if ($ProcessCanvasApps -eq $True) {
+          $parameter += "--processCanvasApps"
         }
 
         Write-Host "##[group]Syncing solution $SolutionUniqueName"
-        pac solution sync --async --packagetype Both --processCanvasApps
+        & pac solution sync @parameter
         Write-Host "##[endgroup]"
     env:
       Debug: $(System.Debug)
       SolutionUniqueName: ${{ parameters.solutionUniqueName }}
       WorkingDirectory: ${{ parameters.outputDirectory }}
+      ProcessCanvasApps: $[ coalesce(variables.SolutionConfigProcessCanvasApps_Export, 'true') ]

--- a/azure-pipeline-templates/pac-solution/sync.yml
+++ b/azure-pipeline-templates/pac-solution/sync.yml
@@ -58,4 +58,4 @@ steps:
       Debug: $(System.Debug)
       SolutionUniqueName: ${{ parameters.solutionUniqueName }}
       WorkingDirectory: ${{ parameters.outputDirectory }}
-      ProcessCanvasApps: $[ coalesce(variables.SolutionConfigProcessCanvasApps_Export, 'true') ]
+      ProcessCanvasApps: $(SolutionConfigProcessCanvasApps_Export)


### PR DESCRIPTION
Introduce new variable to set flags on solution exports (clone and sync commands). Namely if variable `SolutionConfigProcessCanvasApps_Export` is set to false, this will supress extraction of canvas apps.